### PR TITLE
Use `composedMessage` instead of `formatString`

### DIFF
--- a/Sources/Flannel/Views/LogView.swift
+++ b/Sources/Flannel/Views/LogView.swift
@@ -163,7 +163,7 @@ public struct LogView: View {
                     return FlannelLogEntry(
                         date: $0.date,
                         category: $0.category,
-                        message: $0.formatString,
+                        message: $0.composedMessage,
                         subsytem: $0.subsystem,
                         processId: Int(
                             $0.processIdentifier


### PR DESCRIPTION
Switch to use `composedMessage` instead of `formatString` to ensure string interpolation is correct in the case of Ints/Floats/Strings  etc